### PR TITLE
Set the cluster config port to the secure connect bundle port

### DIFF
--- a/pkg/easycass/session.go
+++ b/pkg/easycass/session.go
@@ -22,6 +22,7 @@ func GetSession(username, password, pathToZip string) (*gocql.Session, error) {
 		Username: username,
 		Password: password,
 	}
+	cluster.Port = zi.port
 	cluster.Hosts = []string{fmt.Sprintf("%s:%d", zi.hostname, zi.port)}
 
 	cluster.SslOpts = &gocql.SslOptions{


### PR DESCRIPTION
Only the control connections are using the correct port to connect then all other connections created are using the default port of 9042 which is incorrect and they're timing out.